### PR TITLE
associate ctrl inputs with flow chart ctrl data

### DIFF
--- a/src/components/controls_panel/controlComponent.js
+++ b/src/components/controls_panel/controlComponent.js
@@ -47,6 +47,7 @@ const ControlComponent = ({ ctrlObj, theme, results, updateCtrlValue, attachPara
                         functionName: nodeFunctionName,
                         param,
                         nodeId: node.id,
+                        inputId: ctrlObj.id,
                       }
                   });
               });
@@ -79,7 +80,7 @@ const ControlComponent = ({ ctrlObj, theme, results, updateCtrlValue, attachPara
           console.log('filteredResult:', filteredResult);
           nd = filteredResult === undefined ? {} : filteredResult;
           if(Object.keys(nd).length > 0) {
-            plotData = 'data' in nd.result
+            plotData = nd.result && 'data' in nd.result
               ? nd.result.data
               : [{'x': nd.result['x0'], 'y': nd.result['y0'] }];
           }
@@ -90,7 +91,11 @@ const ControlComponent = ({ ctrlObj, theme, results, updateCtrlValue, attachPara
     const inputNodeId = ctrlObj?.param?.nodeId;
     const inputNode = elements.find((e) => e.id === inputNodeId);
     const ctrls = inputNode?.data?.ctrls;
-    let currentInputValue = ctrls ? ctrls[ctrlObj?.param?.id]?.value : 0;
+    const fnParams = FUNCTION_PARAMETERS[ctrlObj?.param?.functionName] || {};
+    const fnParam = fnParams[ctrlObj?.param?.param];
+    const defaultValue = fnParam?.default || 0;
+    
+    let currentInputValue = ctrls ? ctrls[ctrlObj?.param?.id]?.value : defaultValue;
 
     return (
         <div>

--- a/src/components/flow_chart_panel/PARAMETERS_MANIFEST.js
+++ b/src/components/flow_chart_panel/PARAMETERS_MANIFEST.js
@@ -1,13 +1,13 @@
 export const FUNCTION_PARAMETERS = {
     SINE: {
-        frequency: {type: 'float'},
-        offset: {type: 'float'},
-        amplitude: {type: 'float'},
-        waveform: {type: 'select'},
+        frequency: {type: 'float', default: '1'},
+        offset: {type: 'float', default: '0'},
+        amplitude: {type: 'float', default: '1'},
+        waveform: {type: 'select', options: ["sine", "square", "triangle", "sawtooth"], default: 'sine'},
     },
     LINSPACE: {
-        start: {type: 'float'},
-        end: {type: 'float'},
-        step: {type: 'float'},
+        start: {type: 'float', default: '0'},
+        end: {type: 'float', default: '0'},
+        step: {type: 'float', default: '1'},
     },    
 };

--- a/src/hooks/useFlowChartState.ts
+++ b/src/hooks/useFlowChartState.ts
@@ -95,14 +95,27 @@ export function useFlowChartState() {
 
   const updateCtrlInputDataForNode = (
     nodeId: string,
-    inputId: string,
+    paramId: string,
     inputData: any
   ) => {
     setElements((elements) => {
       const node = elements.find((e) => e.id === nodeId);
       if (node) {
         node.data.ctrls = node.data.ctrls || {};
-        node.data.ctrls[inputId] = inputData;
+        node.data.ctrls[paramId] = inputData;
+      }
+    });
+  };
+
+  const removeCtrlInputDataForNode = (
+    nodeId: string,
+    paramId: string,
+  ) => {
+    setElements((elements) => {
+      const node = elements.find((e) => e.id === nodeId);
+      if (node) {
+        node.data.ctrls = node.data.ctrls || {};
+        delete node.data.ctrls[paramId];
       }
     });
   };
@@ -114,6 +127,7 @@ export function useFlowChartState() {
     setElements,
     rfSpatialInfo,
     updateCtrlInputDataForNode,
+    removeCtrlInputDataForNode,
     ctrlsManifest,
     setCtrlsManifest,
     loadFlowExportObject,


### PR DESCRIPTION
Added following
- Added support for default values in the `PARAMETERS_MANIFEST` file
- Each input in CTRL Panel now associates with a single ctrl data parameter
- When an input is removed or its param is changed, the currently associated param's values is reset the default of it's type
