### PR TITLE
#256 implement support to mock a node function

### DIFF
--- a/PYTHON/FUNCTIONS/SIMULATIONS/RAND.py
+++ b/PYTHON/FUNCTIONS/SIMULATIONS/RAND.py
@@ -7,11 +7,20 @@ def RAND(v, params):
     x = None
     if len(v) > 0:
         x = v[0].y
-        # For now return fixed value for y key
-        # Later on, A env variable will be used to return fixed value for testing
-        y = x
-        # y = np.random.normal(size=len(x))
+        y = np.random.normal(size=len(x))
     else:
-        y = np.full(1000, 1000)
+        y = np.random.normal(size=1000)
 
+    return DataContainer(x=x, y=y)
+
+
+@flojoy
+def RAND_MOCK(v, params):
+    print('running mock version of rand')
+    x = None
+    if len(v) > 0:
+        x = v[0].y
+        y = x
+    else:
+        y = np.full(1000, 1000) # for reproducibility returning an array with constant values
     return DataContainer(x=x, y=y)

--- a/PYTHON/WATCH/watch.py
+++ b/PYTHON/WATCH/watch.py
@@ -35,6 +35,7 @@ from utils.topology import Topology
 from common.CONSTANTS import KEY_ALL_JOBEST_IDS
 
 
+ENV_CI = 'CI'
 stream = open('STATUS_CODES.yml', 'r')
 STATUS_CODES = yaml.safe_load(stream)
 
@@ -49,11 +50,14 @@ class FlowScheduler:
 
     def run(self):
         print('\nrun jobset:', self.jobset_id)
+        self.is_ci = os.getenv(key=ENV_CI, default=False);
+        print('is running in CI?', self.is_ci)
         self.nx_graph = reactflow_to_networkx(self.flow_chart['nodes'], self.flow_chart['edges'])
         self.topology = Topology(graph=self.nx_graph)
         self.topology.print_id_to_label_mapping()
         self.topology.print_graph()
         self.topology.collect_ready_jobs()
+
 
         num_times_waited_for_new_jobs = 0
         wait_time_for_new_jobs = 0.1
@@ -103,7 +107,6 @@ class FlowScheduler:
         self.topology.print_graph()
         self.notify_jobset_finished()
         print('finished proceessing jobset', self.jobset_id, '\n')
-        return
 
     def process_job_result(self, job_id, job_result, success):
         '''
@@ -135,7 +138,17 @@ class FlowScheduler:
 
         node = self.nx_graph.nodes[job_id]
         cmd = node['cmd']
+        cmd_mock = node['cmd'] + '_MOCK'        
         func = getattr(globals()[cmd], cmd)
+
+        # when running in CI environment use the mock function instead if its defined
+        if self.is_ci:
+            try:
+                func = getattr(globals()[cmd], cmd_mock)
+                print( ' running the mock version:', cmd_mock)
+            except:
+                pass
+
         dependencies = self.topology.get_job_dependencies(job_id, original=True)
         
         print(


### PR DESCRIPTION
# PR for Issue: #256 

## Changes
- Implement support to mock a node function.
- Provides a mock implementation of the RAND function

## How to mock a node?
Just create another function in the same file with the suffix `_MOCK`.
This will be automatically picked up when running with the environment variable `CI=true`

To simulate this in local run rq worker `flojoy-watch` as following
`CI=true rq worker flojoy-watch`

## Testing Performed
- Created an app with just the `RAND` node
- Ran the `flojoy-watch` with `CI=true`
- From the console log I confirmed that it ran the mock version `RAND_MOCK`
- In the frontend `DEBUG` panel
  - I confirmed that the output of the `RAND` node matches the constant value that is returned by the mocked version of the `RAND` node.
  - when I ran without `CI=true`, I confirmed that the output of the `RAND` node is random each time.
