### PR TITLE
Fix/closing rq workers

### DIFF
--- a/close-all-rq-workers.py
+++ b/close-all-rq-workers.py
@@ -16,8 +16,9 @@ print('queue flojoy isEmpty? ', q.is_empty())
 q.empty();
 
 for w in Worker.all(connection=r):
-    try:
-        os.kill(w.pid, signal.SIGTERM) 
-    except OSError:
-        print("No rq workers running")
-        pass
+    if w.pid is not None:  
+        try:
+            os.kill(w.pid, signal.SIGTERM) 
+        except OSError:
+            print("No rq workers running")
+            pass


### PR DESCRIPTION
Changes:
Implemented checking for `pid` value if it is not `None` before killing the process with `os.kill` in `close-all-rq-workers.py` file.