### PR TITLE
Fix constant label changing whenever a new value is entered to parameters

### DIFF
--- a/src/hooks/useFlowChartGraph.ts
+++ b/src/hooks/useFlowChartGraph.ts
@@ -85,7 +85,7 @@ export const useFlowChartGraph = () => {
     setNodes((element) => {
       const node = element.find((e) => e.id === nodeId);
       if (node) {
-        if (node.data.func === "CONSTANT") {
+        if (node.data.func === "CONSTANT" && inputData.param === "constant") {
           node.data.ctrls[inputData.param].value = inputData.value;
           node.data.label = inputData.value?.toString() ?? "CONSTANT";
         } else {


### PR DESCRIPTION
add another condition to validate if parameter name is `constant`