### PR TITLE
Skip environment variable test

### DIFF
--- a/cypress/e2e/04_env_variable_modal.cy.ts
+++ b/cypress/e2e/04_env_variable_modal.cy.ts
@@ -1,7 +1,7 @@
 /// <reference types="cypress" />
 
-// Test doesn't pass due to needing to unlock the system keyring
-// in order to add a new credential. Skipping until we can find a workaround for this.
+// FIXME: Test doesn't pass due to needing to unlock the system keyring in order
+// to add a new credential. Skipping until we can find a workaround for this.
 describe.skip("Verify Env Variable Modal", () => {
   it("env variable modal test", () => {
     cy.visit("/").wait(1000);

--- a/cypress/e2e/04_env_variable_modal.cy.ts
+++ b/cypress/e2e/04_env_variable_modal.cy.ts
@@ -1,8 +1,8 @@
 /// <reference types="cypress" />
 
-import { text } from "stream/consumers";
-
-describe("Verify Env Variable Modal", () => {
+// Test doesn't pass due to needing to unlock the system keyring
+// in order to add a new credential. Skipping until we can find a workaround for this.
+describe.skip("Verify Env Variable Modal", () => {
   it("env variable modal test", () => {
     cy.visit("/").wait(1000);
     cy.get('[data-testid="close-welcome-modal"]').click();


### PR DESCRIPTION
Test can't pass due to needing to unlock the system keyring.