### PR TITLE
Make node delay use milliseconds instead of seconds

### DIFF
--- a/captain/utils/flowchart_utils.py
+++ b/captain/utils/flowchart_utils.py
@@ -61,7 +61,7 @@ def create_topology(
         task_queue=task_queue,
         cleanup_func=cleanup_func,
         worker_response=worker_response,
-        node_delay=request.nodeDelay,
+        node_delay=request.nodeDelay / 1000,
         final_broadcast=final_broadcast,
     )
 

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -22,7 +22,7 @@ const settingsAtom = atomWithImmer<Setting[]>([
     title: "Node Delay",
     key: "nodeDelay",
     group: "backend",
-    desc: "Delay before running the next node in seconds",
+    desc: "Delay before running the next node in milliseconds",
     value: 0,
   },
   {


### PR DESCRIPTION
Previously it was impossible to set the node delay as a fraction of a second, so this addresses the issue by just using milliseconds (input is still locked to integer values)