### PR TITLE
Add max workers setting

### DIFF
--- a/captain/models/topology.py
+++ b/captain/models/topology.py
@@ -443,7 +443,7 @@ class Topology:
     # assuming LOOP is the only dependency of all the nodes,
     # and the LOOP node has 2 sucessors from "body" (node1, node2) and 1 from "end" (end),
     # we will spawn 3 workers instead of the logical amount which is 2.
-    def get_maximum_workers(self, maximum_capacity: int = 4):
+    def get_maximum_workers(self, maximum_capacity: int = 1):
         max_independant = 0
         temp_graph = deepcopy(self.original_graph)
         queue = deque()

--- a/captain/types/flowchart.py
+++ b/captain/types/flowchart.py
@@ -12,6 +12,7 @@ class PostWFC(BaseModel):
     cancelExistingJobs: bool
     nodeDelay: float
     maximumRuntime: float
+    maximumConcurrentWorkers: int
 
 
 class WorkerSuccessResponse(BaseModel):

--- a/captain/utils/flowchart_utils.py
+++ b/captain/utils/flowchart_utils.py
@@ -68,12 +68,17 @@ def create_topology(
 
 # spawns a set amount of workers to execute jobs (node functions)
 def spawn_workers(
-    manager: Manager, imported_functions: dict[str, Any], node_delay: float , max_workers: int
+    manager: Manager,
+    imported_functions: dict[str, Any],
+    node_delay: float,
+    max_workers: int,
 ):
     if manager.running_topology is None:
         logger.error("Could not spawn workers, no topology detected")
         return
-    worker_number = manager.running_topology.get_maximum_workers(maximum_capacity=max_workers)
+    worker_number = manager.running_topology.get_maximum_workers(
+        maximum_capacity=max_workers
+    )
     logger.debug(f"NEED {worker_number} WORKERS")
     logger.info(f"Spawning {worker_number} workers")
     manager.thread_count = worker_number

--- a/captain/utils/flowchart_utils.py
+++ b/captain/utils/flowchart_utils.py
@@ -68,12 +68,12 @@ def create_topology(
 
 # spawns a set amount of workers to execute jobs (node functions)
 def spawn_workers(
-    manager: Manager, imported_functions: dict[str, Any], node_delay: float = 0
+    manager: Manager, imported_functions: dict[str, Any], node_delay: float , max_workers: int
 ):
     if manager.running_topology is None:
         logger.error("Could not spawn workers, no topology detected")
         return
-    worker_number = manager.running_topology.get_maximum_workers()
+    worker_number = manager.running_topology.get_maximum_workers(maximum_capacity=max_workers)
     logger.debug(f"NEED {worker_number} WORKERS")
     logger.info(f"Spawning {worker_number} workers")
     manager.thread_count = worker_number
@@ -261,7 +261,7 @@ async def prepare_jobs_and_run_fc(request: PostWFC, manager: Manager):
     socket_msg["SYSTEM_STATUS"] = STATUS_CODES["RUN_IN_PROCESS"]
     await manager.ws.broadcast(socket_msg)
 
-    spawn_workers(manager, funcs, request.nodeDelay)
+    spawn_workers(manager, funcs, request.nodeDelay, request.maximumConcurrentWorkers)
     logger.debug(
         f"PRE JOB OPERATION TOOK {time.time() - pre_job_op_start} SECONDS TO COMPLETE"
     )

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -33,6 +33,13 @@ const settingsAtom = atomWithImmer<Setting[]>([
     value: 3000,
   },
   {
+    title: "Maximum Concurrent Workers",
+    key: "maximumConcurrentWorkers",
+    group: "backend",
+    desc: "Maximum number of nodes that can be executed at the same time",
+    value: 4,
+  },
+  {
     title: "Fit view on resize",
     key: "fitViewOnResize",
     group: "frontend",


### PR DESCRIPTION
Temporary band-aid on a bigger issue: refer to "STU-122: LOOP +1 and LOOP INDEX mismatch" on Linear

This PR will default single-threading for the app (1 worker) but can be adjusted. With the default, we won't run into concurrency issues and race conditions. 