### PR TITLE
Mecademic hardware UI Integration

### DIFF
--- a/captain/routes/devices.py
+++ b/captain/routes/devices.py
@@ -13,4 +13,5 @@ async def get_devices():
         cameras=device_finder.get_cameras(),
         serialDevices=device_finder.get_serial_devices(),
         visaDevices=device_finder.get_visa_devices(),
+        mecademicDevices=device_finder.get_mecademic_devices(),
     )

--- a/captain/services/hardware.py
+++ b/captain/services/hardware.py
@@ -4,7 +4,7 @@ import cv2
 import subprocess
 from sys import platform
 
-from captain.types.devices import CameraDevice, SerialDevice, VISADevice
+from captain.types.devices import CameraDevice, SerialDevice, VISADevice, MecademicDevice
 
 __all__ = ["get_device_finder"]
 
@@ -58,6 +58,11 @@ class DefaultDeviceFinder:
             except pyvisa.VisaIOError:
                 pass
 
+        return devices
+
+    def get_mecademic_devices(self) -> list[MecademicDevice]:
+        """Returns a list of Mecademic devices connected to the system."""
+        devices = [MecademicDevice(name="Flojoy's Mecademic Meca500", ip="192.168.0.100")]
         return devices
 
 

--- a/captain/types/devices.py
+++ b/captain/types/devices.py
@@ -21,7 +21,13 @@ class VISADevice(BaseModel):
     description: str
 
 
+class MecademicDevice(BaseModel):
+    name: str
+    ip: str
+
+
 class DeviceInfo(BaseModel):
     cameras: list[CameraDevice]
     serialDevices: list[SerialDevice]
     visaDevices: list[VISADevice]
+    mecademicDevices: list[MecademicDevice]

--- a/captain/utils/manifest/build_manifest.py
+++ b/captain/utils/manifest/build_manifest.py
@@ -52,6 +52,7 @@ SPECIAL_TYPES = [
     SerialDevice,
     VisaDevice,
     CameraConnection,
+    MecademicConnection,
     SerialConnection,
     VisaConnection,
 ]

--- a/src/feature/common/types/ParamValueType.ts
+++ b/src/feature/common/types/ParamValueType.ts
@@ -15,4 +15,5 @@ export type ParamValueType =
   | "CameraConnection"
   | "SerialConnection"
   | "VisaConnection"
+  | "MecademicConnection"
   | "unknown";

--- a/src/feature/device_panel/components/HardwareInfo.tsx
+++ b/src/feature/device_panel/components/HardwareInfo.tsx
@@ -53,6 +53,14 @@ export const HardwareInfo = () => {
         }))
       : undefined;
 
+  const mecademicDevices: DeviceCardProps[] | undefined =
+    devices.mecademicDevices.length > 0
+      ? devices.mecademicDevices.map((d) => ({
+          name: d.name,
+          port: d.ip,
+        }))
+      : undefined;
+
   return (
     <div>
       <Button onClick={refetch}>Refresh</Button>
@@ -62,6 +70,8 @@ export const HardwareInfo = () => {
       <DeviceSection title="Serial" devices={serialDevices} />
       <div className="py-6" />
       <DeviceSection title="VISA" devices={visaDevices} />
+      <div className="py-6" />
+      <DeviceSection title="Mecademic" devices={mecademicDevices} />
     </div>
   );
 };

--- a/src/feature/flow_chart_panel/components/node-edit-menu/MecademicDeviceSelect.tsx
+++ b/src/feature/flow_chart_panel/components/node-edit-menu/MecademicDeviceSelect.tsx
@@ -1,0 +1,18 @@
+import { useHardwareDevices } from "@src/hooks/useHardwareDevices";
+import { DeviceSelect, SelectProps } from "./DeviceSelect";
+
+export const MecademicDeviceSelect = (props: SelectProps) => {
+  const hardware = useHardwareDevices();
+  const mecas = hardware?.mecademicDevices;
+
+  return (
+    <DeviceSelect
+      {...props}
+      devices={mecas}
+      placeholder="No cameras found"
+      keySelector={(meca) => meca.ip.toString()}
+      valueSelector={(meca) => meca.ip.toString()}
+      nameSelector={(meca) => meca.name}
+    />
+  );
+};

--- a/src/feature/flow_chart_panel/components/node-edit-menu/ParamField.tsx
+++ b/src/feature/flow_chart_panel/components/node-edit-menu/ParamField.tsx
@@ -15,6 +15,8 @@ import { useHasUnsavedChanges } from "@src/hooks/useHasUnsavedChanges";
 import { CameraSelect } from "./CameraSelect";
 import { SerialDeviceSelect } from "./SerialDeviceSelect";
 import { VisaDeviceSelect } from "./VisaDeviceSelect";
+import React from "react";
+import { MecademicDeviceSelect } from "@feature/flow_chart_panel/components/node-edit-menu/MecademicDeviceSelect";
 
 type ParamFieldProps = {
   nodeId: string;
@@ -129,6 +131,8 @@ const ParamField = ({
     case "VisaDevice":
     case "VisaConnection":
       return <VisaDeviceSelect onValueChange={handleChange} value={value} />;
+      case "MecademicConnection":
+        return <MecademicDeviceSelect onValueChange={handleChange} value={value} />;
     case "str":
     case "list[int]":
     case "list[float]":

--- a/src/hooks/useHardwareDevices.ts
+++ b/src/hooks/useHardwareDevices.ts
@@ -25,12 +25,18 @@ const VISADevice = z.object({
   description: z.string(),
 });
 
+const MecademicDevice = z.object({
+  ip: z.string(),
+  name: z.string(),
+});
+
 type VISADevice = z.infer<typeof VISADevice>;
 
 const DeviceInfo = z.object({
   cameras: z.array(CameraDevice),
   serialDevices: z.array(SerialDevice),
   visaDevices: z.array(VISADevice),
+  mecademicDevices: z.array(MecademicDevice),
 });
 
 type DeviceInfo = z.infer<typeof DeviceInfo>;


### PR DESCRIPTION
A rudimentary version of mecademic support in the hardware UI for Flojoy.
<img width="1123" alt="Screenshot 2023-10-02 at 10 21 39 AM" src="https://github.com/flojoy-ai/studio/assets/45843308/d76b9494-f788-47ea-9493-47786350a000">


# Known issues

- Mecademic doesn't provide API to scan for arms on the network, and Flojoy hardware integration doesn't allow for hardware that can't be indexed. Because of this, this demo hardcodes the default IP address for mecademic in lieu of a custom connection UI
- Mecademic's connection handle should in the same Python server as the nodes, so it can't be managed fully externally on the hardware connections server. Because of this, the implementation is just passing around possible IP addresses to connect to

# Possible ways forward

- Enhance hardware connections API to support custom connections (IE a + button). This would allow a user to type in an IP and test the connection in the hardware connections UI, and add it to the dropdown list for the medemic node. This increases consistency but adds friction
- Do the same as above, but remove the connect node in lieu of implicit connection management through expansion of the previous mecademic connection manager
- Use the current hardware API as much as possible - scan through all IPs, find one that responds to mecademic requests, hope their API never changes, populate the list of mecademic arms using results.