### PR TITLE
Fix: Run Test sequencer without test | Init tree as a root with children 

### DIFF
--- a/src/renderer/hooks/useTestSequencerState.ts
+++ b/src/renderer/hooks/useTestSequencerState.ts
@@ -17,7 +17,11 @@ import {
 } from "@/renderer/utils/TestSequenceValidator";
 import useWithPermission from "./useWithPermission";
 
-export const testSequenceTree = atom<TestRootNode>({type: "root", children: [], identifiers: []} as TestRootNode);
+export const testSequenceTree = atom<TestRootNode>({
+  type: "root",
+  children: [],
+  identifiers: [],
+} as TestRootNode);
 
 export const curRun = atom<string[]>([]);
 

--- a/src/renderer/hooks/useTestSequencerState.ts
+++ b/src/renderer/hooks/useTestSequencerState.ts
@@ -17,7 +17,7 @@ import {
 } from "@/renderer/utils/TestSequenceValidator";
 import useWithPermission from "./useWithPermission";
 
-export const testSequenceTree = atom<TestRootNode>({} as TestRootNode);
+export const testSequenceTree = atom<TestRootNode>({type: "root", children: [], identifiers: []} as TestRootNode);
 
 export const curRun = atom<string[]>([]);
 


### PR DESCRIPTION
Invalid pydantic modal was crashing the socket