### PR TITLE
STU-312 fix NI DAQ without chassis error when getting chassis' name

### DIFF
--- a/captain/services/hardware.py
+++ b/captain/services/hardware.py
@@ -119,7 +119,6 @@ class DefaultDeviceFinder:
         except nidaqmx.errors.DaqNotFoundError as e:
             logging.warn(f"NI-DAQmx driver not installed - {e}")
         except Exception as e:
-
             logging.error(f"Error in get_nidaqmx_devices: {e}")
         return []
 

--- a/captain/services/hardware.py
+++ b/captain/services/hardware.py
@@ -86,10 +86,15 @@ class DefaultDeviceFinder:
             devices = []
 
             def extract_device(channel, device) -> NIDAQmxDevice:
+                description = "NI-DAQmx Device"
+                try:
+                    description = f"{device.product_type} - {device.compact_daq_chassis_device}/{device.compact_daq_slot_num}"
+                except Exception as e:
+                    logging.warn("Can't extract device description: " + str(e))
                 return NIDAQmxDevice(
                     name=f"{device.product_type} - {channel.name.split('/')[-1]}",
                     address=channel.name,
-                    description=f"{device.product_type} - {device.compact_daq_chassis_device}/{device.compact_daq_slot_num}",
+                    description=description,
                 )
 
             for device in system.devices:
@@ -114,6 +119,7 @@ class DefaultDeviceFinder:
         except nidaqmx.errors.DaqNotFoundError as e:
             logging.warn(f"NI-DAQmx driver not installed - {e}")
         except Exception as e:
+
             logging.error(f"Error in get_nidaqmx_devices: {e}")
         return []
 


### PR DESCRIPTION
I'm just complaining, how are we supposed to know that this throws?
```
    @property
    def compact_daq_chassis_device(self):
        """
        :class:`nidaqmx.system.device.Device`: Indicates the name of the
            CompactDAQ chassis that contains this module.
        """

        val = self._interpreter.get_device_attribute_string(self._name, 0x29b7)
        return _DeviceAlternateConstructor(val, self._interpreter)
```

Potential fix for SamChi Pulpan's error in Discord