### PR TITLE
[STU-339] Display total number step by sequence or cycle

### DIFF
--- a/src/renderer/hooks/useTestSequencerState.ts
+++ b/src/renderer/hooks/useTestSequencerState.ts
@@ -374,7 +374,8 @@ export function useSequencerState() {
       toast.error("Please fill in the required fields to upload to cloud.");
     }
     setIsUploaded(false);
-    if (project === null) {
+    if (sequences.length === 0) {
+      // No sequence ? Run the loaded test step.
       setIsLocked(true);
       runRunnableSequencesFromCurrentOne(sender);
     } else {

--- a/src/renderer/routes/test_sequencer_panel/components/CyclePanel.tsx
+++ b/src/renderer/routes/test_sequencer_panel/components/CyclePanel.tsx
@@ -7,7 +7,11 @@ import { Button } from "@/renderer/components/ui/button";
 import { CycleConfig } from "@/renderer/types/test-sequencer";
 import { useShallow } from "zustand/react/shallow";
 import { useSequencerStore } from "@/renderer/stores/sequencer";
-import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/renderer/components/ui/hover-card";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/renderer/components/ui/hover-card";
 
 export function CyclePanel() {
   const { tree, isLocked } = useDisplayedSequenceState();

--- a/src/renderer/routes/test_sequencer_panel/components/CyclePanel.tsx
+++ b/src/renderer/routes/test_sequencer_panel/components/CyclePanel.tsx
@@ -3,15 +3,11 @@ import { Input } from "@/renderer/components/ui/input";
 import { useDisplayedSequenceState } from "@/renderer/hooks/useTestSequencerState";
 import LockableButton from "./lockable/LockedButtons";
 import { Checkbox } from "@/renderer/components/ui/checkbox";
-import {
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
-} from "@radix-ui/react-hover-card";
 import { Button } from "@/renderer/components/ui/button";
 import { CycleConfig } from "@/renderer/types/test-sequencer";
 import { useShallow } from "zustand/react/shallow";
 import { useSequencerStore } from "@/renderer/stores/sequencer";
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/renderer/components/ui/hover-card";
 
 export function CyclePanel() {
   const { tree, isLocked } = useDisplayedSequenceState();
@@ -51,9 +47,9 @@ export function CyclePanel() {
           </code>
         </Button>
       </HoverCardTrigger>
-      <HoverCardContent className="w-320 z-20 mt-2 rounded-lg border bg-card px-3 py-2 text-card-foreground shadow-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
+      <HoverCardContent className="mt-2">
         <div>
-          <h2 className="mt-2 text-center text-lg font-bold text-accent1">
+          <h2 className="text-center text-lg font-bold text-accent1">
             Cycle Configuration
           </h2>
           <div className="my-3 flex items-center gap-2">
@@ -85,7 +81,7 @@ export function CyclePanel() {
 
           <hr />
 
-          <div className="my-3 flex items-center gap-2">
+          <div className="mt-3 flex items-center gap-2">
             <LockableButton
               variant="outline"
               isLocked={_.isEmpty(tree)}

--- a/src/renderer/routes/test_sequencer_panel/components/DesignBar.tsx
+++ b/src/renderer/routes/test_sequencer_panel/components/DesignBar.tsx
@@ -24,7 +24,11 @@ import { useImportSequences } from "@/renderer/hooks/useTestSequencerProject";
 import { CyclePanel } from "./CyclePanel";
 import { useSequencerStore } from "@/renderer/stores/sequencer";
 import { useShallow } from "zustand/react/shallow";
-import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/renderer/components/ui/hover-card";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/renderer/components/ui/hover-card";
 
 export type Summary = {
   successRate: number;
@@ -144,26 +148,33 @@ export function DesignBar() {
 
         <div className="grow" />
 
-        { sequences.length <= 1 ? (
+        {sequences.length <= 1 ? (
           <code className="inline-flex items-center justify-center p-3 text-sm text-muted-foreground">
-            Test {summary.numberOfTestRunInSeq + "/" + summary.numberOfTestInSeq}
+            Test{" "}
+            {summary.numberOfTestRunInSeq + "/" + summary.numberOfTestInSeq}
           </code>
         ) : (
           <HoverCard>
             <HoverCardTrigger asChild>
-              <Button variant="link" >
+              <Button variant="link">
                 <code className="inline-flex items-center justify-center p-3 text-sm text-muted-foreground">
-                  Test {displayTotal ? summary.numberOfTestRunInTotal + "/" + summary.numberOfTestInTotal : summary.numberOfTestRunInSeq + "/" + summary.numberOfTestInSeq
-                  }
+                  Test{" "}
+                  {displayTotal
+                    ? summary.numberOfTestRunInTotal +
+                      "/" +
+                      summary.numberOfTestInTotal
+                    : summary.numberOfTestRunInSeq +
+                      "/" +
+                      summary.numberOfTestInSeq}
                 </code>
               </Button>
             </HoverCardTrigger>
-            <HoverCardContent className="w-48 mt-2">
+            <HoverCardContent className="mt-2 w-48">
               <div>
                 <h2 className="text-center text-lg font-bold text-accent1">
                   Display by
                 </h2>
-                <div className="mt-3 flex gap-2 items-center">
+                <div className="mt-3 flex items-center gap-2">
                   <Button
                     variant="outline"
                     onClick={() => setDisplayTotal(!displayTotal)}
@@ -225,13 +236,21 @@ const getNumberOfTestRunInSeq = (data: TestSequenceElement[]): number => {
   );
 };
 
-const getNumberOfTestRunInTotal = (sequences: TestSequenceContainer[]): number => {
-  return sequences.reduce((acc, seq) => acc + getNumberOfTestRunInSeq(seq.elements), 0);
-}
+const getNumberOfTestRunInTotal = (
+  sequences: TestSequenceContainer[],
+): number => {
+  return sequences.reduce(
+    (acc, seq) => acc + getNumberOfTestRunInSeq(seq.elements),
+    0,
+  );
+};
 
 const getNumberOfTestInTotal = (sequences: TestSequenceContainer[]): number => {
-  return sequences.reduce((acc, seq) => acc + getNumberOfTestInSeq(seq.elements), 0);
-}
+  return sequences.reduce(
+    (acc, seq) => acc + getNumberOfTestInSeq(seq.elements),
+    0,
+  );
+};
 
 const getNumberOfSequence = (data: TestSequenceContainer[]): number => {
   return countWhere(data, (elem) => elem.runable);
@@ -266,10 +285,10 @@ export const getGlobalStatus = (
   const highestCycle =
     cycleRuns.length > 0
       ? cycleRuns
-        .map((el) => getGlobalStatus([], el, []))
-        .reduce((prev, curr) =>
-          priority[prev] > priority[curr] ? prev : curr,
-        )
+          .map((el) => getGlobalStatus([], el, []))
+          .reduce((prev, curr) =>
+            priority[prev] > priority[curr] ? prev : curr,
+          )
       : "pending";
   if (sequences.length === 0 && data.length === 0) return highestCycle;
   // Highest in the view

--- a/src/renderer/routes/test_sequencer_panel/components/DesignBar.tsx
+++ b/src/renderer/routes/test_sequencer_panel/components/DesignBar.tsx
@@ -144,42 +144,47 @@ export function DesignBar() {
 
         <div className="grow" />
 
-        <HoverCard>
-          <HoverCardTrigger asChild>
-            <Button variant="link" >
-              <code className="inline-flex items-center justify-center p-3 text-sm text-muted-foreground">
-                Test {displayTotal ? summary.numberOfTestRunInTotal + "/" + summary.numberOfTestInTotal : summary.numberOfTestRunInSeq + "/" + summary.numberOfTestInSeq
-                }
-              </code>
-            </Button>
-          </HoverCardTrigger>
-          <HoverCardContent className="w-48 mt-2 rounded-lg border bg-card">
-            <div>
-              <h2 className="text-center text-lg font-bold text-accent1">
-                Display by
-              </h2>
-              <div className="mt-3 flex gap-2 items-center">
-                <Button
-                  variant="outline"
-                  onClick={() => setDisplayTotal(!displayTotal)}
-                  className="h-6"
-                  disabled={!displayTotal}
-                >
-                  <p className="text-xs">Sequence</p>
-                </Button>
-                <Button
-                  variant="outline"
-                  onClick={() => setDisplayTotal(!displayTotal)}
-                  className="h-6"
-                  disabled={displayTotal}
-                >
-                  <p className="text-xs">Total</p>
-                </Button>
+        { sequences.length === 0 ? (
+          <code className="inline-flex items-center justify-center p-3 text-sm text-muted-foreground">
+            Test {summary.numberOfTestRunInSeq + "/" + summary.numberOfTestInSeq}
+          </code>
+        ) : (
+          <HoverCard>
+            <HoverCardTrigger asChild>
+              <Button variant="link" >
+                <code className="inline-flex items-center justify-center p-3 text-sm text-muted-foreground">
+                  Test {displayTotal ? summary.numberOfTestRunInTotal + "/" + summary.numberOfTestInTotal : summary.numberOfTestRunInSeq + "/" + summary.numberOfTestInSeq
+                  }
+                </code>
+              </Button>
+            </HoverCardTrigger>
+            <HoverCardContent className="w-48 mt-2">
+              <div>
+                <h2 className="text-center text-lg font-bold text-accent1">
+                  Display by
+                </h2>
+                <div className="mt-3 flex gap-2 items-center">
+                  <Button
+                    variant="outline"
+                    onClick={() => setDisplayTotal(!displayTotal)}
+                    className="h-6"
+                    disabled={!displayTotal}
+                  >
+                    <p className="text-xs">Sequence</p>
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={() => setDisplayTotal(!displayTotal)}
+                    className="h-6"
+                    disabled={displayTotal}
+                  >
+                    <p className="text-xs">Total</p>
+                  </Button>
+                </div>
               </div>
-            </div>
-          </HoverCardContent>
-        </HoverCard>
-
+            </HoverCardContent>
+          </HoverCard>
+        )}
 
         <code className="inline-flex items-center justify-center p-3 text-sm text-muted-foreground">
           Sequence{" "}

--- a/src/renderer/routes/test_sequencer_panel/components/DesignBar.tsx
+++ b/src/renderer/routes/test_sequencer_panel/components/DesignBar.tsx
@@ -29,6 +29,7 @@ import {
   HoverCardContent,
   HoverCardTrigger,
 } from "@/renderer/components/ui/hover-card";
+import _ from "lodash";
 
 export type Summary = {
   successRate: number;
@@ -160,12 +161,8 @@ export function DesignBar() {
                 <code className="inline-flex items-center justify-center p-3 text-sm text-muted-foreground">
                   Test{" "}
                   {displayTotal
-                    ? summary.numberOfTestRunInTotal +
-                      "/" +
-                      summary.numberOfTestInTotal
-                    : summary.numberOfTestRunInSeq +
-                      "/" +
-                      summary.numberOfTestInSeq}
+                    ? `${summary.numberOfTestRunInTotal} / ${summary.numberOfTestInTotal}`
+                    : `${summary.numberOfTestRunInSeq} / ${summary.numberOfTestInSeq}`}
                 </code>
               </Button>
             </HoverCardTrigger>
@@ -273,6 +270,7 @@ export const getGlobalStatus = (
   interface WithStatus {
     status: string;
   }
+
   const priority = {
     pending: 0,
     pass: 1,
@@ -281,6 +279,7 @@ export const getGlobalStatus = (
     paused: 4,
     running: 5,
   };
+
   // Find highest priority in cycle
   const highestCycle =
     cycleRuns.length > 0
@@ -290,15 +289,20 @@ export const getGlobalStatus = (
             priority[prev] > priority[curr] ? prev : curr,
           )
       : "pending";
+
   if (sequences.length === 0 && data.length === 0) return highestCycle;
+
   // Highest in the view
   const tests = data.filter((el) => el.type === "test") as Test[];
   const iter = sequences.length > 0 ? sequences : tests;
+
   const status = iter
     .map((el: WithStatus) => el.status)
     .reduce((prev, curr) => (priority[prev] > priority[curr] ? prev : curr));
+
   const highestGlobal =
     priority[highestCycle] > priority[status] ? highestCycle : status;
+
   return StatusType.parse(highestGlobal);
 };
 

--- a/src/renderer/routes/test_sequencer_panel/components/DesignBar.tsx
+++ b/src/renderer/routes/test_sequencer_panel/components/DesignBar.tsx
@@ -314,4 +314,3 @@ const mapStatusToDisplay: { [k in StatusType] } = {
     </Status>
   ),
 };
-

--- a/src/renderer/routes/test_sequencer_panel/components/DesignBar.tsx
+++ b/src/renderer/routes/test_sequencer_panel/components/DesignBar.tsx
@@ -31,16 +31,6 @@ import {
 } from "@/renderer/components/ui/hover-card";
 import _ from "lodash";
 
-export type Summary = {
-  successRate: number;
-  numberOfTestRunInSeq: number;
-  numberOfTestInSeq: number;
-  numberOfTestRunInTotal: number;
-  numberOfTestInTotal: number;
-  numberOfSequenceRun: number;
-  numberOfSequence: number;
-  status: StatusType;
-};
 
 export function DesignBar() {
   const { setIsImportTestModalOpen, setIsCreateProjectModalOpen } =
@@ -55,18 +45,17 @@ export function DesignBar() {
   const { isAdmin } = useWithPermission();
   const importSequences = useImportSequences();
 
-  const [summary, setSummary] = useState<Summary>({
-    numberOfTestRunInSeq: 0,
-    numberOfTestInSeq: 0,
-    numberOfTestRunInTotal: 0,
-    numberOfTestInTotal: 0,
-    numberOfSequenceRun: 0,
-    numberOfSequence: 0,
-    successRate: 0,
-    status: "pending",
-  });
-  useMemo(() => {
-    setSummary({
+  const {
+    numberOfTestRunInSeq,
+    numberOfTestInSeq,
+    numberOfTestRunInTotal,
+    numberOfTestInTotal,
+    numberOfSequenceRun,
+    numberOfSequence,
+    successRate,
+    status,
+  } = useMemo(() => {
+    return {
       numberOfTestRunInSeq: getNumberOfTestRunInSeq(elems),
       numberOfTestInSeq: getNumberOfTestInSeq(elems),
       numberOfTestRunInTotal: getNumberOfTestRunInTotal(sequences),
@@ -75,7 +64,7 @@ export function DesignBar() {
       numberOfSequenceRun: getNumberOfSequenceRun(sequences),
       successRate: getSuccessRate(elems),
       status: getGlobalStatus(cycleRuns, sequences, elems),
-    });
+    };
   }, [elems, sequences, cycleRuns]);
 
   const [displayTotal, setDisplayTotal] = useState(false);
@@ -152,17 +141,17 @@ export function DesignBar() {
         {sequences.length <= 1 ? (
           <code className="inline-flex items-center justify-center p-3 text-sm text-muted-foreground">
             Test{" "}
-            {summary.numberOfTestRunInSeq + "/" + summary.numberOfTestInSeq}
+            {numberOfTestRunInSeq + "/" + numberOfTestInSeq}
           </code>
         ) : (
           <HoverCard>
             <HoverCardTrigger asChild>
               <Button variant="link">
-                <code className="inline-flex items-center justify-center p-3 text-sm text-muted-foreground">
+                <code className="inline-flex translate-y-[2px] translate-x-[4px] items-center justify-center text-sm text-muted-foreground">
                   Test{" "}
                   {displayTotal
-                    ? `${summary.numberOfTestRunInTotal} / ${summary.numberOfTestInTotal}`
-                    : `${summary.numberOfTestRunInSeq} / ${summary.numberOfTestInSeq}`}
+                    ? `${numberOfTestRunInTotal}/${numberOfTestInTotal}`
+                    : `${numberOfTestRunInSeq}/${numberOfTestInSeq}`}
                 </code>
               </Button>
             </HoverCardTrigger>
@@ -196,7 +185,7 @@ export function DesignBar() {
 
         <code className="inline-flex items-center justify-center p-3 text-sm text-muted-foreground">
           Sequence{" "}
-          {summary.numberOfSequenceRun + "/" + summary.numberOfSequence}
+          {numberOfSequenceRun + "/" + numberOfSequence}
         </code>
 
         <CyclePanel />
@@ -206,7 +195,7 @@ export function DesignBar() {
           id="app-status"
           className="text-md m-1 inline-flex h-8 w-40 items-center justify-center rounded-md border font-semibold text-primary transition-colors"
         >
-          {mapStatusToDisplay[summary.status]}
+          {mapStatusToDisplay[status]}
         </div>
       </div>
       <div className="py-1" />

--- a/src/renderer/routes/test_sequencer_panel/components/DesignBar.tsx
+++ b/src/renderer/routes/test_sequencer_panel/components/DesignBar.tsx
@@ -225,17 +225,11 @@ const getNumberOfTestRunInSeq = (data: TestSequenceElement[]): number => {
 const getNumberOfTestRunInTotal = (
   sequences: TestSequenceContainer[],
 ): number => {
-  return sequences.reduce(
-    (acc, seq) => acc + getNumberOfTestRunInSeq(seq.elements),
-    0,
-  );
+  return _.sum(sequences.map(seq => getNumberOfTestRunInSeq(seq.elements)));
 };
 
 const getNumberOfTestInTotal = (sequences: TestSequenceContainer[]): number => {
-  return sequences.reduce(
-    (acc, seq) => acc + getNumberOfTestInSeq(seq.elements),
-    0,
-  );
+  return _.sum(sequences.map(seq => getNumberOfTestInSeq(seq.elements)));
 };
 
 const getNumberOfSequence = (data: TestSequenceContainer[]): number => {

--- a/src/renderer/routes/test_sequencer_panel/components/DesignBar.tsx
+++ b/src/renderer/routes/test_sequencer_panel/components/DesignBar.tsx
@@ -31,7 +31,6 @@ import {
 } from "@/renderer/components/ui/hover-card";
 import _ from "lodash";
 
-
 export function DesignBar() {
   const { setIsImportTestModalOpen, setIsCreateProjectModalOpen } =
     useSequencerModalStore();
@@ -140,14 +139,13 @@ export function DesignBar() {
 
         {sequences.length <= 1 ? (
           <code className="inline-flex items-center justify-center p-3 text-sm text-muted-foreground">
-            Test{" "}
-            {numberOfTestRunInSeq + "/" + numberOfTestInSeq}
+            Test {numberOfTestRunInSeq + "/" + numberOfTestInSeq}
           </code>
         ) : (
           <HoverCard>
             <HoverCardTrigger asChild>
               <Button variant="link">
-                <code className="inline-flex translate-y-[2px] translate-x-[4px] items-center justify-center text-sm text-muted-foreground">
+                <code className="inline-flex translate-x-[4px] translate-y-[2px] items-center justify-center text-sm text-muted-foreground">
                   Test{" "}
                   {displayTotal
                     ? `${numberOfTestRunInTotal}/${numberOfTestInTotal}`
@@ -184,8 +182,7 @@ export function DesignBar() {
         )}
 
         <code className="inline-flex items-center justify-center p-3 text-sm text-muted-foreground">
-          Sequence{" "}
-          {numberOfSequenceRun + "/" + numberOfSequence}
+          Sequence {numberOfSequenceRun + "/" + numberOfSequence}
         </code>
 
         <CyclePanel />
@@ -225,11 +222,11 @@ const getNumberOfTestRunInSeq = (data: TestSequenceElement[]): number => {
 const getNumberOfTestRunInTotal = (
   sequences: TestSequenceContainer[],
 ): number => {
-  return _.sum(sequences.map(seq => getNumberOfTestRunInSeq(seq.elements)));
+  return _.sum(sequences.map((seq) => getNumberOfTestRunInSeq(seq.elements)));
 };
 
 const getNumberOfTestInTotal = (sequences: TestSequenceContainer[]): number => {
-  return _.sum(sequences.map(seq => getNumberOfTestInSeq(seq.elements)));
+  return _.sum(sequences.map((seq) => getNumberOfTestInSeq(seq.elements)));
 };
 
 const getNumberOfSequence = (data: TestSequenceContainer[]): number => {

--- a/src/renderer/routes/test_sequencer_panel/components/DesignBar.tsx
+++ b/src/renderer/routes/test_sequencer_panel/components/DesignBar.tsx
@@ -144,7 +144,7 @@ export function DesignBar() {
 
         <div className="grow" />
 
-        { sequences.length === 0 ? (
+        { sequences.length <= 1 ? (
           <code className="inline-flex items-center justify-center p-3 text-sm text-muted-foreground">
             Test {summary.numberOfTestRunInSeq + "/" + summary.numberOfTestInSeq}
           </code>
@@ -178,7 +178,7 @@ export function DesignBar() {
                     className="h-6"
                     disabled={displayTotal}
                   >
-                    <p className="text-xs">Total</p>
+                    <p className="text-xs">Cycle</p>
                   </Button>
                 </div>
               </div>

--- a/src/renderer/routes/test_sequencer_panel/components/DesignBar.tsx
+++ b/src/renderer/routes/test_sequencer_panel/components/DesignBar.tsx
@@ -1,6 +1,5 @@
 import { useSequencerModalStore } from "@/renderer/stores/modal";
 import { useDisplayedSequenceState } from "@/renderer/hooks/useTestSequencerState";
-import { filter } from "lodash";
 import { Button } from "@/renderer/components/ui/button";
 import { ACTIONS_HEIGHT } from "@/renderer/routes/common/Layout";
 import { FlaskConical, Import, LayoutGrid, Plus, Route } from "lucide-react";
@@ -11,7 +10,6 @@ import {
   TestSequenceElement,
 } from "@/renderer/types/test-sequencer";
 import { useMemo, useState } from "react";
-import { getOnlyCompletedTests } from "./data-table/utils";
 import useWithPermission from "@/renderer/hooks/useWithPermission";
 import {
   DropdownMenu,
@@ -51,7 +49,6 @@ export function DesignBar() {
     numberOfTestInTotal,
     numberOfSequenceRun,
     numberOfSequence,
-    successRate,
     status,
   } = useMemo(() => {
     return {
@@ -61,7 +58,6 @@ export function DesignBar() {
       numberOfTestInTotal: getNumberOfTestInTotal(sequences),
       numberOfSequence: getNumberOfSequence(sequences),
       numberOfSequenceRun: getNumberOfSequenceRun(sequences),
-      successRate: getSuccessRate(elems),
       status: getGlobalStatus(cycleRuns, sequences, elems),
     };
   }, [elems, sequences, cycleRuns]);
@@ -319,10 +315,3 @@ const mapStatusToDisplay: { [k in StatusType] } = {
   ),
 };
 
-const getSuccessRate = (data: TestSequenceElement[]): number => {
-  const tests = getOnlyCompletedTests(data);
-  if (tests.length == 0) return 0;
-  return (
-    (filter(tests, (elem) => elem.status == "pass").length / tests.length) * 100
-  );
-};


### PR DESCRIPTION
- [X]  New: Ability to display by cycle
- [X]  Toggle between the two
- [X]  Only give ability once multiple cycles are loaded
- [X]  Convert Cycle Pop Up from radix-ui to shadcn + Pruning unused CSS
- [X]  Fix: once all sequences are deleted, a dev was not able to run the tests