### PR TITLE
[STU-340] Ability to know Admin / Viewer + general UI & UX

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -29,8 +29,8 @@ const App = () => {
     <div>
       <Toaster theme={resolvedTheme} richColors closeButton />
       <SocketReceiver />
-      <div className="titlebar flex h-12 items-center justify-center bg-background font-bold">
-        Flojoy Studio ({packageJson.version})
+      <div className="titlebar flex h-8 items-center justify-center bg-background font-bold">
+        Flojoy Studio
       </div>
       <Routes>
         <Route path="/" element={<Index />} />

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -8,8 +8,6 @@ import ControlPanelTab from "./routes/control_panel/control-panel-view";
 import { useTheme } from "@/renderer/providers/theme-provider";
 import { Layout } from "./routes/common/Layout";
 import { Index } from "./routes/index";
-// eslint-disable-next-line no-restricted-imports
-import packageJson from "../../package.json";
 import EditorView from "./routes/editor/EditorView";
 import AuthPage from "./routes/auth/Auth";
 import { Toaster } from "sonner";

--- a/src/renderer/components/auth/ProfileBox.tsx
+++ b/src/renderer/components/auth/ProfileBox.tsx
@@ -154,7 +154,7 @@ const ProfileBox = ({
           </div>
         </div>
 
-        <p className="text-sm">{user.name.slice(0, 20)}</p>
+        <p className="text-sm text-ellipsis overflow-hidden w-full text-center">{user.name}</p>
       </div>
       <ConfirmPrompt
         open={openConfirmPrompt}

--- a/src/renderer/components/auth/ProfileBox.tsx
+++ b/src/renderer/components/auth/ProfileBox.tsx
@@ -154,7 +154,7 @@ const ProfileBox = ({
           </div>
         </div>
 
-        <p className="text-sm">{user.name}</p>
+        <p className="text-sm">{user.name.slice(0, 20)}</p>
       </div>
       <ConfirmPrompt
         open={openConfirmPrompt}

--- a/src/renderer/components/auth/ProfileBox.tsx
+++ b/src/renderer/components/auth/ProfileBox.tsx
@@ -154,7 +154,9 @@ const ProfileBox = ({
           </div>
         </div>
 
-        <p className="text-sm text-ellipsis overflow-hidden w-full text-center">{user.name}</p>
+        <p className="w-full overflow-hidden text-ellipsis text-center text-sm">
+          {user.name}
+        </p>
       </div>
       <ConfirmPrompt
         open={openConfirmPrompt}

--- a/src/renderer/routes/common/Layout.tsx
+++ b/src/renderer/routes/common/Layout.tsx
@@ -4,7 +4,7 @@ import StatusBar from "@/renderer/routes/common/StatusBar";
 
 export const HEADER_HEIGHT = 72;
 export const ACTIONS_HEIGHT = 52;
-export const BOTTOM_STATUS_BAR_HEIGHT = 64;
+export const BOTTOM_STATUS_BAR_HEIGHT = 53;
 
 export const LAYOUT_TOP_HEIGHT = HEADER_HEIGHT + ACTIONS_HEIGHT;
 

--- a/src/renderer/routes/common/Layout.tsx
+++ b/src/renderer/routes/common/Layout.tsx
@@ -5,15 +5,12 @@ import StatusBar from "@/renderer/routes/common/StatusBar";
 export const HEADER_HEIGHT = 72;
 export const ACTIONS_HEIGHT = 52;
 export const BOTTOM_STATUS_BAR_HEIGHT = 53;
-
 export const LAYOUT_TOP_HEIGHT = HEADER_HEIGHT + ACTIONS_HEIGHT;
-
-export const LAYOUT_TOP_HEIGHT_FLOWCHART = LAYOUT_TOP_HEIGHT;
 
 export const Layout = () => {
   return (
     <div>
-      <div className="relative bg-background px-8 py-2">
+      <div className="relative bg-background px-8 py-4">
         <Header />
       </div>
       <main

--- a/src/renderer/routes/common/Sidebar/Sidebar.tsx
+++ b/src/renderer/routes/common/Sidebar/Sidebar.tsx
@@ -4,7 +4,7 @@ import { Leaf, RootNode } from "@/renderer/types/manifest";
 import SidebarNode from "./SidebarNode";
 import {
   ACTIONS_HEIGHT,
-  LAYOUT_TOP_HEIGHT_FLOWCHART,
+  LAYOUT_TOP_HEIGHT,
 } from "@/renderer/routes/common/Layout";
 import { ArrowDownWideNarrow, ArrowUpWideNarrow, XIcon } from "lucide-react";
 import { Button } from "@/renderer/components/ui/button";
@@ -86,8 +86,8 @@ const Sidebar = ({
     <div
       data-testid="sidebar"
       style={{
-        top: LAYOUT_TOP_HEIGHT_FLOWCHART + ctrlBarOffset,
-        height: `calc(100vh - ${LAYOUT_TOP_HEIGHT_FLOWCHART}px)`,
+        top: LAYOUT_TOP_HEIGHT  + ctrlBarOffset,
+        height: `calc(100vh - ${LAYOUT_TOP_HEIGHT}px)`,
       }}
       className={cn(
         "absolute bottom-0 z-50 flex flex-col overflow-hidden bg-modal pl-6 pt-4 sm:w-96",

--- a/src/renderer/routes/common/StatusBar.tsx
+++ b/src/renderer/routes/common/StatusBar.tsx
@@ -72,7 +72,7 @@ const StatusBar = (): JSX.Element => {
                 <Badge variant={"destructive"}>Disconnected - {packageJson.version}</Badge>
               )}
             </div>
-            {activeTab === "Flowchart" || activeTab === "Control Panel" ? (
+            {activeTab !== "Test Sequencer" && activeTab !== "Device Manager" ? (
               <>
                 <div
                   data-cy="app-status"

--- a/src/renderer/routes/common/StatusBar.tsx
+++ b/src/renderer/routes/common/StatusBar.tsx
@@ -36,14 +36,14 @@ const StatusBar = (): JSX.Element => {
   return (
     <div
       className={cn(
-        "fixed bottom-0 z-30 mt-6 w-full translate-y-[calc(100%-60px)] transition-transform duration-700 ease-in-out",
+        "fixed bottom-0 z-30 w-full translate-y-[calc(100%-40px)] transition-transform duration-700 ease-in-out",
         { "translate-y-0": !minimize },
       )}
     >
       <div
         className={cn("relative flex", {
           "flex-col justify-start overflow-y-scroll ": !minimize,
-          "row items-center justify-between bg-background": minimize,
+          "row h-10 items-center justify-between bg-background": minimize,
         })}
         style={{
           maxHeight: `calc(100vh - ${
@@ -60,22 +60,24 @@ const StatusBar = (): JSX.Element => {
             ) : (
               <Badge variant={"destructive"}>Disconnected</Badge>
             )}
-            <div className="text-sm">
-              {messages[messages.length - 1]?.slice(0, 145)}...
+            <div className="text-xs">
+              <code>
+                {messages[messages.length - 1]?.slice(0, 145)}...
+              </code>
             </div>
           </div>
         )}
         <div
           className={cn(
-            "sticky right-0 top-0 z-50 flex h-full w-full justify-end p-3",
+            "sticky right-0 top-0 z-50 flex h-full w-full justify-end",
             {
               "w-full p-0": !minimize,
             },
           )}
         >
           <Button
-            variant={"outline"}
-            className="w-29 rounded-none  "
+            variant="link"
+            className="w-29 rounded-none text-xs"
             onClick={() => setMinimize((p) => !p)}
           >
             {minimize ? "Expand log" : "Collapse log"}
@@ -83,11 +85,11 @@ const StatusBar = (): JSX.Element => {
         </div>
         {!minimize && (
           <Button
-            variant={"outline"}
-            className=" fixed bottom-0 right-0 rounded-none"
+            variant="ghost"
+            className="fixed bottom-0 right-0 m-1 text-xs"
             onClick={handleDownloadLogs}
           >
-            <DownloadIcon size={19} className="mr-2" />
+            <DownloadIcon size={16} className="mr-2" />
             Download Full Logs
           </Button>
         )}

--- a/src/renderer/routes/common/StatusBar.tsx
+++ b/src/renderer/routes/common/StatusBar.tsx
@@ -62,14 +62,14 @@ const StatusBar = (): JSX.Element => {
         }}
       >
         {minimize && (
-          <div className="flex min-w-fit items-center gap-2 ps-2 w-full">
+          <div className="flex min-w-fit items-center gap-2 px-2 mb-1 w-full">
             <div>
             {![ServerStatus.OFFLINE, ServerStatus.CONNECTING].includes(
               serverStatus,
             ) ? (
-              <Badge>Operational - {packageJson.version}</Badge>
+              <Badge variant="outline">Operational - {packageJson.version}</Badge>
             ) : (
-              <Badge variant={"destructive"}>Disconnected</Badge>
+              <Badge variant={"destructive"}>Disconnected  - {packageJson.version}</Badge>
             )}
             </div>
             { activeTab === "Flowchart" || activeTab === "Control Panel" ? (

--- a/src/renderer/routes/common/StatusBar.tsx
+++ b/src/renderer/routes/common/StatusBar.tsx
@@ -61,18 +61,22 @@ const StatusBar = (): JSX.Element => {
         }}
       >
         {minimize && (
-
           <div className="flex w-full min-w-fit items-center gap-2 ps-2">
             <div>
               {![ServerStatus.OFFLINE, ServerStatus.CONNECTING].includes(
                 serverStatus,
               ) ? (
-                <Badge variant="outline">Operational - {packageJson.version}</Badge>
+                <Badge variant="outline">
+                  Operational - {packageJson.version}
+                </Badge>
               ) : (
-                <Badge variant={"destructive"}>Disconnected - {packageJson.version}</Badge>
+                <Badge variant={"destructive"}>
+                  Disconnected - {packageJson.version}
+                </Badge>
               )}
             </div>
-            {activeTab !== "Test Sequencer" && activeTab !== "Device Manager" ? (
+            {activeTab !== "Test Sequencer" &&
+            activeTab !== "Device Manager" ? (
               <>
                 <div
                   data-cy="app-status"

--- a/src/renderer/routes/common/StatusBar.tsx
+++ b/src/renderer/routes/common/StatusBar.tsx
@@ -67,18 +67,17 @@ const StatusBar = (): JSX.Element => {
             {![ServerStatus.OFFLINE, ServerStatus.CONNECTING].includes(
               serverStatus,
             ) ? (
-              <Badge>Studio - {packageJson.version}</Badge>
+              <Badge>Operational - {packageJson.version}</Badge>
             ) : (
               <Badge variant={"destructive"}>Disconnected</Badge>
             )}
             </div>
             { activeTab === "Flowchart" || activeTab === "Control Panel" ? (
               <>
-                <div className="grow" />
                 <div 
                   data-cy="app-status"
                   id="app-status"
-                  className="flex text-xs"
+                  className="flex text-xs ml-2"
                 >
                   <code>
                     {serverStatus}

--- a/src/renderer/routes/common/StatusBar.tsx
+++ b/src/renderer/routes/common/StatusBar.tsx
@@ -9,12 +9,21 @@ import { cn } from "@/renderer/lib/utils";
 import { Button } from "@/renderer/components/ui/button";
 import { DownloadIcon } from "lucide-react";
 import { useSocketStore } from "@/renderer/stores/socket";
+// eslint-disable-next-line no-restricted-imports
+import packageJson from "../../../../package.json";
+import { useAppStore } from "@/renderer/stores/app";
+import { useShallow } from "zustand/react/shallow";
 
 const StatusBar = (): JSX.Element => {
   const [messages, setMessages] = useState<string[]>([]);
   const serverStatus = useSocketStore((state) => state.serverStatus);
   const [minimize, setMinimize] = useState(true);
   const lastElem = useRef<HTMLDivElement>(null);
+  const { activeTab } = useAppStore(
+    useShallow((state) => ({
+      activeTab: state.activeTab,
+    })),
+  );
 
   useEffect(() => {
     if (lastElem.current?.scrollIntoView) {
@@ -32,6 +41,7 @@ const StatusBar = (): JSX.Element => {
       setMessages((prev) => (prev.includes(data) ? prev : [...prev, data]));
     });
   }, []);
+
 
   return (
     <div
@@ -52,24 +62,43 @@ const StatusBar = (): JSX.Element => {
         }}
       >
         {minimize && (
-          <div className="flex min-w-fit items-center gap-2 ps-2">
+          <div className="flex min-w-fit items-center gap-2 ps-2 w-full">
+            <div>
             {![ServerStatus.OFFLINE, ServerStatus.CONNECTING].includes(
               serverStatus,
             ) ? (
-              <Badge>Operational</Badge>
+              <Badge>Studio - {packageJson.version}</Badge>
             ) : (
               <Badge variant={"destructive"}>Disconnected</Badge>
             )}
-            <div className="text-xs">
-              <code>
-                {messages[messages.length - 1]?.slice(0, 145)}...
-              </code>
             </div>
+            { activeTab === "Flowchart" || activeTab === "Control Panel" ? (
+              <>
+                <div className="grow" />
+                <div 
+                  data-cy="app-status"
+                  id="app-status"
+                  className="flex text-xs"
+                >
+                  <code>
+                    {serverStatus}
+                  </code>
+                </div>
+              </>
+              ) : (
+                <>
+                  <code className="text-xs">
+                    {messages[messages.length - 1]?.slice(0, 145)}...
+                  </code>
+                  <div className="grow" />
+                </>
+              )}
+            <div className="grow" />
           </div>
         )}
         <div
           className={cn(
-            "sticky right-0 top-0 z-50 flex h-full w-full justify-end",
+            "sticky right-0 top-0 z-50 flex h-full justify-end w-32",
             {
               "w-full p-0": !minimize,
             },
@@ -77,7 +106,7 @@ const StatusBar = (): JSX.Element => {
         >
           <Button
             variant="link"
-            className="w-29 rounded-none text-xs"
+            className="w-29 text-xs"
             onClick={() => setMinimize((p) => !p)}
           >
             {minimize ? "Expand log" : "Collapse log"}

--- a/src/renderer/routes/control_panel/control-panel-view.tsx
+++ b/src/renderer/routes/control_panel/control-panel-view.tsx
@@ -48,7 +48,6 @@ import { toast } from "sonner";
 import { useContextMenu } from "@/renderer/hooks/useContextMenu";
 import { deepMutableClone } from "@/renderer/utils/clone";
 import { Link } from "react-router-dom";
-import { useSocketStore } from "@/renderer/stores/socket";
 import FlowControlButtons from "../flow_chart/views/ControlBar/FlowControlButtons";
 import _ from "lodash";
 import { Input } from "@/renderer/components/ui/input";
@@ -202,7 +201,6 @@ const ControlPanelView = () => {
       }
     : undefined;
 
-  const serverStatus = useSocketStore((state) => state.serverStatus);
 
   const { setProjectName, projectName, hasUnsavedChanges } = useProjectStore(
     useShallow((state) => ({
@@ -282,13 +280,6 @@ const ControlPanelView = () => {
           </Button>
           <ClearCanvasBtn clearCanvas={clearCanvas} />
           <div className="grow" />
-          <div
-            data-cy="app-status"
-            id="app-status"
-            className="mr-5 flex items-center justify-center text-sm"
-          >
-            <code>{serverStatus}</code>
-          </div>
 
           <Link to="/flowchart" data-cy="script-btn">
             <Button

--- a/src/renderer/routes/control_panel/control-panel-view.tsx
+++ b/src/renderer/routes/control_panel/control-panel-view.tsx
@@ -231,7 +231,7 @@ const ControlPanelView = () => {
           zIndex: 10,
         }}
       >
-        <div className="felx inline-flex items-center gap-2 px-4 pt-1">
+        <div className="inline-flex items-center gap-2 px-4 pt-1">
           <Input
             className={
               "h-6 w-28 overflow-hidden overflow-ellipsis whitespace-nowrap border-muted/60 text-sm focus:border-muted-foreground focus:ring-0 focus:ring-offset-0 focus-visible:ring-0 sm:w-48"

--- a/src/renderer/routes/control_panel/control-panel-view.tsx
+++ b/src/renderer/routes/control_panel/control-panel-view.tsx
@@ -257,9 +257,9 @@ const ControlPanelView = () => {
             : onWidgetConfigSubmit
         }
       />
-      <div className="mx-8 border-b" style={{ height: ACTIONS_HEIGHT }}>
+      <div className="border-b" style={{ height: ACTIONS_HEIGHT }}>
         <div className="py-1" />
-        <div className="flex">
+        <div className="mx-8 flex">
           <NewWidgetModal
             open={newWidgetModalOpen}
             setOpen={setNewWidgetModalOpen}

--- a/src/renderer/routes/control_panel/control-panel-view.tsx
+++ b/src/renderer/routes/control_panel/control-panel-view.tsx
@@ -225,6 +225,29 @@ const ControlPanelView = () => {
       >
         <FlowControlButtons />
       </div>
+      <div
+        style={{
+          height: ACTIONS_HEIGHT,
+          position: "absolute",
+          top: `calc(${LAYOUT_TOP_HEIGHT + ACTIONS_HEIGHT}px + 20px)`,
+          left: "12px",
+          zIndex: 10,
+        }}
+      >
+        <div className="felx inline-flex items-center gap-2 px-4 pt-1">
+          <Input
+            className={
+              "h-6 w-28 overflow-hidden overflow-ellipsis whitespace-nowrap border-muted/60 text-sm focus:border-muted-foreground focus:ring-0 focus:ring-offset-0 focus-visible:ring-0 sm:w-48"
+            }
+            value={projectName}
+            onChange={(e) => setProjectName(e.target.value)}
+            placeholder="Untitled project"
+          />
+          {hasUnsavedChanges && (
+            <div className=" h-2 w-2 rounded-full bg-foreground/50" />
+          )}
+        </div>
+      </div>
       <ConfigDialog
         initialValues={widgetConfig.current}
         open={widgetConfigOpen}
@@ -259,20 +282,6 @@ const ControlPanelView = () => {
           </Button>
           <ClearCanvasBtn clearCanvas={clearCanvas} />
           <div className="grow" />
-          <div className="felx inline-flex items-center gap-2 px-4 pt-1">
-            {hasUnsavedChanges && (
-              <div className=" h-2 w-2 rounded-full bg-foreground/50" />
-            )}
-            <Input
-              className={
-                "h-6 w-28 overflow-hidden overflow-ellipsis whitespace-nowrap border-muted/60 text-sm focus:border-muted-foreground focus:ring-0 focus:ring-offset-0 focus-visible:ring-0 sm:w-48"
-              }
-              value={projectName}
-              onChange={(e) => setProjectName(e.target.value)}
-              placeholder="Untitled project"
-            />
-          </div>
-          <div />
           <div
             data-cy="app-status"
             id="app-status"

--- a/src/renderer/routes/flow_chart/FlowChartTabView.tsx
+++ b/src/renderer/routes/flow_chart/FlowChartTabView.tsx
@@ -293,6 +293,29 @@ const FlowChartTab = () => {
         >
           <FlowControlButtons />
         </div>
+        <div
+          style={{
+            height: ACTIONS_HEIGHT,
+            position: "absolute",
+            top: `calc(${LAYOUT_TOP_HEIGHT + ACTIONS_HEIGHT}px + 20px)`,
+            left: "12px",
+            zIndex: 10,
+          }}
+        >
+          <div className="felx inline-flex items-center gap-2 px-4 pt-1">
+            <Input
+              className={
+                "h-6 w-28 overflow-hidden overflow-ellipsis whitespace-nowrap border-muted/60 text-sm focus:border-muted-foreground focus:ring-0 focus:ring-offset-0 focus-visible:ring-0 sm:w-48"
+              }
+              value={projectName}
+              onChange={(e) => setProjectName(e.target.value)}
+              placeholder="Untitled project"
+            />
+            {hasUnsavedChanges && (
+              <div className=" h-2 w-2 rounded-full bg-foreground/50" />
+            )}
+          </div>
+        </div>
         <div className="mx-8 border-b" style={{ height: ACTIONS_HEIGHT }}>
           <div className="py-1" />
           <div className="flex">
@@ -365,20 +388,6 @@ const FlowChartTab = () => {
               </>
             )}
             <div className="grow" />
-            <div className="felx inline-flex items-center gap-2 px-4 pt-1">
-              {hasUnsavedChanges && (
-                <div className=" h-2 w-2 rounded-full bg-foreground/50" />
-              )}
-              <Input
-                className={
-                  "h-6 w-28 overflow-hidden overflow-ellipsis whitespace-nowrap border-muted/60 text-sm focus:border-muted-foreground focus:ring-0 focus:ring-offset-0 focus-visible:ring-0 sm:w-48"
-                }
-                value={projectName}
-                onChange={(e) => setProjectName(e.target.value)}
-                placeholder="Untitled project"
-              />
-            </div>
-            <div />
             <div
               data-cy="app-status"
               id="app-status"
@@ -477,7 +486,7 @@ const FlowChartTab = () => {
             />
             <Controls
               fitViewOptions={{ padding: 0.8 }}
-              className="!bottom-1 !shadow-control"
+              className="!bottom-1 !shadow-control ml-20"
             />
             {menu && (
               <BlockContextMenu

--- a/src/renderer/routes/flow_chart/FlowChartTabView.tsx
+++ b/src/renderer/routes/flow_chart/FlowChartTabView.tsx
@@ -269,7 +269,6 @@ const FlowChartTab = () => {
   );
 
   const addBlockReady = manifest !== undefined;
-  const serverStatus = useSocketStore((state) => state.serverStatus);
 
   const { setProjectName, projectName, hasUnsavedChanges } = useProjectStore(
     useShallow((state) => ({
@@ -388,13 +387,6 @@ const FlowChartTab = () => {
               </>
             )}
             <div className="grow" />
-            <div
-              data-cy="app-status"
-              id="app-status"
-              className="mr-5 flex items-center justify-center text-sm"
-            >
-              <code>{serverStatus}</code>
-            </div>
 
             <Link to="/control" data-cy="control-btn">
               <Button

--- a/src/renderer/routes/flow_chart/FlowChartTabView.tsx
+++ b/src/renderer/routes/flow_chart/FlowChartTabView.tsx
@@ -315,9 +315,9 @@ const FlowChartTab = () => {
             )}
           </div>
         </div>
-        <div className="mx-8 border-b" style={{ height: ACTIONS_HEIGHT }}>
+        <div className="border-b" style={{ height: ACTIONS_HEIGHT }}>
           <div className="py-1" />
-          <div className="flex">
+          <div className="mx-8 flex">
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger asChild>

--- a/src/renderer/routes/flow_chart/FlowChartTabView.tsx
+++ b/src/renderer/routes/flow_chart/FlowChartTabView.tsx
@@ -301,7 +301,7 @@ const FlowChartTab = () => {
             zIndex: 10,
           }}
         >
-          <div className="felx inline-flex items-center gap-2 px-4 pt-1">
+          <div className="inline-flex items-center gap-2 px-4 pt-1">
             <Input
               className={
                 "h-6 w-28 overflow-hidden overflow-ellipsis whitespace-nowrap border-muted/60 text-sm focus:border-muted-foreground focus:ring-0 focus:ring-offset-0 focus-visible:ring-0 sm:w-48"

--- a/src/renderer/routes/flow_chart/views/ControlBar.tsx
+++ b/src/renderer/routes/flow_chart/views/ControlBar.tsx
@@ -24,7 +24,6 @@ import { useShallow } from "zustand/react/shallow";
 import FeedbackModal from "./FeedbackModal";
 import { SaveSequencesButton } from "@/renderer/routes/test_sequencer_panel/components/control-bar/SaveButton";
 import { ImportSequencesButton } from "@/renderer/routes/test_sequencer_panel/components/control-bar/ImportButton";
-import { Icons } from "@/renderer/assets/icons";
 
 const ControlBar = () => {
   const { activeTab } = useAppStore(

--- a/src/renderer/routes/flow_chart/views/ControlBar.tsx
+++ b/src/renderer/routes/flow_chart/views/ControlBar.tsx
@@ -165,12 +165,18 @@ const ControlBar = () => {
 
           <MenubarMenu>
             <MenubarTrigger onClick={() => setIsFeedbackModalOpen(true)}>
-              <Icons.discord className="h-5 w-5" />
+              Discord
             </MenubarTrigger>
+          </MenubarMenu>
+          <MenubarMenu>
           </MenubarMenu>
         </Menubar>
       </div>
-      <ProfileMenu />
+      <Menubar>
+        <MenubarMenu>
+        <ProfileMenu />
+        </MenubarMenu>
+      </Menubar>
       <DarkModeToggle />
     </div>
   );

--- a/src/renderer/routes/flow_chart/views/user-profile/ProfileMenu.tsx
+++ b/src/renderer/routes/flow_chart/views/user-profile/ProfileMenu.tsx
@@ -10,7 +10,6 @@ import {
 import { KeyIcon, UserPlus2 } from "lucide-react";
 import { Fragment, useState } from "react";
 import { PasswordModal } from "./PasswordModal";
-import { getAlphabetAvatar } from "@/renderer/utils/text-wrap";
 import { CreateUserProfile } from "@/renderer/components/common/CreateProfileModal";
 import { useAuth } from "@/renderer/context/auth.context";
 import { useNavigate } from "react-router-dom";
@@ -29,7 +28,7 @@ const ProfileMenu = () => {
     <Fragment>
       <DropdownMenu>
         <DropdownMenuTrigger className="flex gap-2 px-2 items-center">
-          {user.name.slice(0, 20)}
+          {user.name.slice(0, 10)}
           { user.role === "Admin" ? (
             <Badge> Admin </Badge>
             ) : (

--- a/src/renderer/routes/flow_chart/views/user-profile/ProfileMenu.tsx
+++ b/src/renderer/routes/flow_chart/views/user-profile/ProfileMenu.tsx
@@ -1,4 +1,3 @@
-import { Avatar, AvatarFallback } from "@/renderer/components/ui/avatar";
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/src/renderer/routes/flow_chart/views/user-profile/ProfileMenu.tsx
+++ b/src/renderer/routes/flow_chart/views/user-profile/ProfileMenu.tsx
@@ -14,6 +14,7 @@ import { getAlphabetAvatar } from "@/renderer/utils/text-wrap";
 import { CreateUserProfile } from "@/renderer/components/common/CreateProfileModal";
 import { useAuth } from "@/renderer/context/auth.context";
 import { useNavigate } from "react-router-dom";
+import { Badge } from "@/renderer/components/ui/badge";
 
 const ProfileMenu = () => {
   const { user, setUser } = useAuth();
@@ -27,14 +28,15 @@ const ProfileMenu = () => {
   return (
     <Fragment>
       <DropdownMenu>
-        <DropdownMenuTrigger>
-          <Avatar>
-            <AvatarFallback>
-              {getAlphabetAvatar(user.name ?? "")}
-            </AvatarFallback>
-          </Avatar>
+        <DropdownMenuTrigger className="flex gap-2 px-2 items-center">
+          {user.name.slice(0, 20)}
+          { user.role === "Admin" ? (
+            <Badge> Admin </Badge>
+            ) : (
+            <Badge> Viewer </Badge>
+          )}
         </DropdownMenuTrigger>
-        <DropdownMenuContent>
+        <DropdownMenuContent className="mt-2">
           <DropdownMenuLabel>{user.role}</DropdownMenuLabel>
           <DropdownMenuSeparator />
           {user.role === "Admin" && (

--- a/src/renderer/routes/test_sequencer_panel/TestSequencerView.tsx
+++ b/src/renderer/routes/test_sequencer_panel/TestSequencerView.tsx
@@ -13,7 +13,7 @@ const TestSequencerView = () => {
   const isLoading = useSequencerStore(useShallow((state) => state.isLoading));
   return (
     <DndProvider backend={HTML5Backend}>
-      <div className="px-12">
+      <div className="px-8">
         {!isLoading && <TestSequencerInfo />}
         {isLoading && (
           <div

--- a/src/renderer/routes/test_sequencer_panel/components/TestSequencerInfo.tsx
+++ b/src/renderer/routes/test_sequencer_panel/components/TestSequencerInfo.tsx
@@ -27,7 +27,7 @@ const TestSequencerView = () => {
         style={{
           height: ACTIONS_HEIGHT,
           position: "absolute",
-          top: `calc(${LAYOUT_TOP_HEIGHT + ACTIONS_HEIGHT}px + 30px)`,
+          top: `calc(${LAYOUT_TOP_HEIGHT + ACTIONS_HEIGHT}px)`,
           right: "50px",
           zIndex: 10,
         }}

--- a/src/renderer/routes/test_sequencer_panel/components/TestSequencerInfo.tsx
+++ b/src/renderer/routes/test_sequencer_panel/components/TestSequencerInfo.tsx
@@ -27,7 +27,7 @@ const TestSequencerView = () => {
         style={{
           height: ACTIONS_HEIGHT,
           position: "absolute",
-          top: `calc(${LAYOUT_TOP_HEIGHT + ACTIONS_HEIGHT}px)`,
+          top: `calc(${LAYOUT_TOP_HEIGHT + ACTIONS_HEIGHT}px + 30px)`,
           right: "50px",
           zIndex: 10,
         }}


### PR DESCRIPTION
# Change list:
- [x] A badge to easily know View or Admin
- [x] Move the Flowchart status to operational bar to allow a small min windows size [for this PR](https://github.com/flojoy-ai/studio/pull/1148)
- [x] Move the Flowchart Name in the upper corner of the ReactFlow view  to allow a small min windows size [for this PR](https://github.com/flojoy-ai/studio/pull/1148)
- [x] Fix Separator gaps in Control and Flowchart view
- [x] Since we are not displaying any avatar ATM -> Display name
- [x] Small Operational Bar at the bottom
- [x] Smaller Header
- [x] Version now in the Operational Bar
- [x] Reduce the user attention on the Operational Bar
    
![image](https://github.com/flojoy-ai/studio/assets/56351875/52b145a7-4ac9-46bf-90b6-573541866148)
![image](https://github.com/flojoy-ai/studio/assets/56351875/578463ae-1481-40d4-bf68-e829addecf64)
