### PR TITLE
Increased timeout on captain requests using ky

### DIFF
--- a/src/renderer/lib/ky.ts
+++ b/src/renderer/lib/ky.ts
@@ -4,4 +4,5 @@ import ky from "ky";
 export const captain = ky.create({
   prefixUrl: "http://" + env.VITE_BACKEND_HOST + ":" + env.VITE_BACKEND_PORT,
   credentials: "include",
+  timeout: 30000,
 });


### PR DESCRIPTION
Opening pull request as a result of investigation of program hanging on "Loading Blocks" on Windows 11 system. Link to discord message for more information: https://discord.com/channels/1120876301809623050/1179493072212590673/1281582054957387777

**Introduced change is changing time in milliseconds before request fails due to timeout error**. On older machines the default value (10 * 1000) may be too small rendering "Loading Blocks" to be stuck and program becoming inoperable. This effect is observed on decent hardware with i5-12500H and 7 GB/s SSD drives. Did not investigate exact details what is the time consuming factor. 
  
At first glance disabling timeout would make sure that requests to captain wouldn't fail due to this reason but realistically it is better to have timeout error thrown and handled in the UI (not the case at the time of writing), but with increased value to maybe half a minute - open to talk about the exact value but this one should work fine.